### PR TITLE
Fix backup file corruption when overwriting a larger existing file

### DIFF
--- a/Stratum.Droid/src/Util/FileUtil.cs
+++ b/Stratum.Droid/src/Util/FileUtil.cs
@@ -57,7 +57,7 @@ namespace Stratum.Droid.Util
 
                 try
                 {
-                    output = context.ContentResolver.OpenOutputStream(uri);
+                    output = context.ContentResolver.OpenOutputStream(uri, "wt");
                     dataStream = new DataOutputStream(output);
 
                     await dataStream.WriteAsync(data);
@@ -81,7 +81,7 @@ namespace Stratum.Droid.Util
 
                 try
                 {
-                    output = context.ContentResolver.OpenOutputStream(uri);
+                    output = context.ContentResolver.OpenOutputStream(uri, "wt");
                     outputWriter = new OutputStreamWriter(output);
                     bufferedWriter = new BufferedWriter(outputWriter);
 


### PR DESCRIPTION
**Problem**

Overwriting an existing backup file with a smaller one (e.g. fewer entries) corrupts the resulting file. On restore, the app rejects the password even though it's correct.

**Cause**

FileUtil.WriteFileAsync opens the destination via ContentResolver.OpenOutputStream(uri), which is a synonym for mode "w". On Android 10+, "w" does not guarantee truncation, so if the new data is shorter than the old file, leftover bytes from the old file stay after it, breaking AES-GCM tag verification on restore.

**Fix**

Use OpenOutputStream(uri, "wt") instead, which explicitly truncates the file before writing.

**Testing**

Created a backup with many entries, then overwrote it (via "replace existing file") with a backup containing fewer entries. Before the fix, restore failed even with the correct password. After the fix, restore succeeds.